### PR TITLE
📝(claude): Update commit-and-pr command documentation

### DIFF
--- a/.claude/commands/commit-and-pr.md
+++ b/.claude/commands/commit-and-pr.md
@@ -1,5 +1,4 @@
-Let's commit the changes. Then commit, push, and create a draft pull request.
+Commit changes, push to remote, and create a draft pull request.
 
-Split large changes: If changes touch multiple concerns, split them into separate commits
-
+For commit creation steps and best practices, refer to @.claude/commands/commit.md
 For PR creation steps and best practices, refer to @.claude/commands/create-pr.md


### PR DESCRIPTION
## Summary

This PR updates the commit-and-pr slash command documentation to make it more concise and better structured.

## Changes

- Simplified command description
- Added references to commit.md and create-pr.md for detailed instructions
- Removed redundant text about splitting large changes

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

N/A - Documentation only change